### PR TITLE
invite interface

### DIFF
--- a/Organization/Changeable.spec.ts
+++ b/Organization/Changeable.spec.ts
@@ -21,6 +21,14 @@ describe("Organization.Changeable", () => {
 		expect(userwidgets.Organization.Changeable.is({ name: "" })).toEqual(false)
 		expect(userwidgets.Organization.Changeable.is({ permissions: ["foo", ""] })).toEqual(false)
 		expect(userwidgets.Organization.Changeable.is({ name: 1 })).toEqual(false)
+		expect(userwidgets.Organization.Changeable.Invite.is({ user: "James@example.com" })).toEqual(true)
+		expect(
+			userwidgets.Organization.Changeable.is({ users: [{ user: "James@example.com" }, "name@example.com"] })
+		).toEqual(true)
+		expect(userwidgets.Organization.Changeable.is({ users: [{ user: 1 }, "name@example.com"] })).toEqual(false)
+		expect(
+			userwidgets.Organization.Changeable.is({ users: [{ name: "James@example.com" }, "name@example.com"] })
+		).toEqual(false)
 	})
 
 	it("get", () => {

--- a/Organization/Changeable.spec.ts
+++ b/Organization/Changeable.spec.ts
@@ -28,10 +28,10 @@ describe("Organization.Changeable", () => {
 			organization
 		)
 	})
-	const invite: userwidgets.Organization.Changeable.Invite = {
-		user: "James@example.com",
-	}
 	it("invite is", () => {
+		const invite: userwidgets.Organization.Changeable.Invite = {
+			user: "James@example.com",
+		}
 		expect(userwidgets.Organization.Changeable.Invite.is(invite)).toEqual(true)
 		expect(userwidgets.Organization.Changeable.is({ users: [invite, "name@example.com"] })).toEqual(true)
 		expect(userwidgets.Organization.Changeable.is({ users: [{ user: 1 }, "name@example.com"] })).toEqual(false)

--- a/Organization/Changeable.spec.ts
+++ b/Organization/Changeable.spec.ts
@@ -21,19 +21,22 @@ describe("Organization.Changeable", () => {
 		expect(userwidgets.Organization.Changeable.is({ name: "" })).toEqual(false)
 		expect(userwidgets.Organization.Changeable.is({ permissions: ["foo", ""] })).toEqual(false)
 		expect(userwidgets.Organization.Changeable.is({ name: 1 })).toEqual(false)
-		expect(userwidgets.Organization.Changeable.Invite.is({ user: "James@example.com" })).toEqual(true)
-		expect(
-			userwidgets.Organization.Changeable.is({ users: [{ user: "James@example.com" }, "name@example.com"] })
-		).toEqual(true)
-		expect(userwidgets.Organization.Changeable.is({ users: [{ user: 1 }, "name@example.com"] })).toEqual(false)
-		expect(
-			userwidgets.Organization.Changeable.is({ users: [{ name: "James@example.com" }, "name@example.com"] })
-		).toEqual(false)
 	})
 
 	it("get", () => {
 		expect(userwidgets.Organization.Changeable.type.get({ ...organization, created: isoly.Date.now() })).toEqual(
 			organization
 		)
+	})
+	const invite: userwidgets.Organization.Changeable.Invite = {
+		user: "James@example.com",
+	}
+	it("invite is", () => {
+		expect(userwidgets.Organization.Changeable.Invite.is(invite)).toEqual(true)
+		expect(userwidgets.Organization.Changeable.is({ users: [invite, "name@example.com"] })).toEqual(true)
+		expect(userwidgets.Organization.Changeable.is({ users: [{ user: 1 }, "name@example.com"] })).toEqual(false)
+		expect(
+			userwidgets.Organization.Changeable.is({ users: [{ name: "James@example.com" }, "name@example.com"] })
+		).toEqual(false)
 	})
 })

--- a/Organization/Changeable.ts
+++ b/Organization/Changeable.ts
@@ -2,9 +2,16 @@ import { isly } from "isly"
 import { Email } from "../Email"
 import type { Organization } from "./index"
 
+// This is an object because it is going to have the invitees permissions on it as well. 
+// Permissions is being worked on in another branch and will be added by that branch when it merges
+interface Invite {
+	user: Email
+	//permissions
+}
+
 export interface Changeable {
 	name?: Organization["name"]
-	users?: Email[]
+	users?: (Email | Invite)[]
 	permissions?: Organization["permissions"]
 }
 export namespace Changeable {

--- a/Organization/Changeable.ts
+++ b/Organization/Changeable.ts
@@ -20,11 +20,13 @@ export namespace Changeable {
 			user: Email.type,
 			//permissions
 		})
+		export const is = type.is
+		export const flaw = type.flaw
 	}
 	export const type = isly.object<Changeable>({
 		name: isly.string(/.+/).optional(),
 		permissions: isly.array(isly.string(/.+/)).optional(),
-		users: isly.array(isly.union(Invite.type, Email.type)).optional(), //update this
+		users: isly.array(isly.union(Invite.type, Email.type)).optional(),
 	})
 	export const is = type.is
 	export const flaw = type.flaw

--- a/Organization/Changeable.ts
+++ b/Organization/Changeable.ts
@@ -2,23 +2,29 @@ import { isly } from "isly"
 import { Email } from "../Email"
 import type { Organization } from "./index"
 
-// This is an object because it is going to have the invitees permissions on it as well. 
+// This is an object because it is going to have the invitees permissions on it as well.
 // Permissions is being worked on in another branch and will be added by that branch when it merges
-interface Invite {
-	user: Email
-	//permissions
-}
 
 export interface Changeable {
 	name?: Organization["name"]
-	users?: (Email | Invite)[]
+	users?: (Email | Changeable.Invite)[]
 	permissions?: Organization["permissions"]
 }
 export namespace Changeable {
+	export interface Invite {
+		user: Email
+		//permissions
+	}
+	export namespace Invite {
+		export const type = isly.object<Invite>({
+			user: Email.type,
+			//permissions
+		})
+	}
 	export const type = isly.object<Changeable>({
 		name: isly.string(/.+/).optional(),
 		permissions: isly.array(isly.string(/.+/)).optional(),
-		users: isly.array(Email.type).optional(),
+		users: isly.array(isly.union(Invite.type, Email.type)).optional(), //update this
 	})
 	export const is = type.is
 	export const flaw = type.flaw

--- a/Organization/index.ts
+++ b/Organization/index.ts
@@ -18,6 +18,9 @@ export namespace Organization {
 	export const Creatable = OrganizationCreatable
 	export type Changeable = OrganizationChangeable
 	export const Changeable = OrganizationChangeable
+	export namespace Changeable {
+		export type Invite = OrganizationChangeable.Invite
+	}
 	export const type = isly.object<Organization>({
 		id: Identifier.type,
 		name: isly.string(/.+/),


### PR DESCRIPTION
This PR is necessary for sending out re-invites to differentiate between those invites we want to send out again and those we dont want to send out again. 