### PR TITLE
Key creatable can have empty permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.8.4",
 			"license": "MIT",
 			"dependencies": {
-				"authly": "^3.0.6",
+				"authly": "^3.0.7",
 				"cloudly-http": "^0.1.6",
 				"cloudly-rest": "^0.1.3",
 				"cryptly": "^3.0.4",
@@ -1902,9 +1902,9 @@
 			}
 		},
 		"node_modules/authly": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/authly/-/authly-3.0.6.tgz",
-			"integrity": "sha512-BvdyoiVH2Y05tnzV2Z11DT1N416CxIzLMysVTASHr5IwecqlvRgCHmoPBDdiAiINUg5d1sG8q2ynqs8we5azoA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/authly/-/authly-3.0.7.tgz",
+			"integrity": "sha512-SScVB+DELRdOfBxcX/5eN9FzntMW6OcqCQ5qUdX608rdo4dXxfJgz+ixuRrww3GrSlPW9yMZjL+mraYACJ6yKg==",
 			"dependencies": {
 				"cryptly": "3.0.4"
 			},

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"watch": "^0.13.0"
 	},
 	"dependencies": {
-		"authly": "^3.0.6",
+		"authly": "^3.0.7",
 		"cloudly-http": "^0.1.6",
 		"cloudly-rest": "^0.1.3",
 		"cryptly": "^3.0.4",


### PR DESCRIPTION
Authly had a bug where falsy values was not converted so flagly could not convert empty strings to empty objects using the transformer.

* updated authly
* removed nesting in another test